### PR TITLE
Propositions suite à première relecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Documentation technique et méthodologique pour la modélisation et la simulatio
 
 ## 🚀 Déploiement automatique sur GitHub Pages
 
-Ce projet est configuré pour un déploiement automatique sur GitHub Pages via GitHub Actions.
+Ce produit est configuré pour un déploiement automatique sur GitHub Pages via GitHub Actions.
 
 ### Configuration
 
@@ -63,7 +63,7 @@ pnpm run docs:build
 pnpm run docs:preview
 ```
 
-## 📁 Structure du projet
+## 📁 Structure du dépôt
 
 ```
 ├── docs/                          # Documentation source

--- a/docs/glossaire.md
+++ b/docs/glossaire.md
@@ -119,4 +119,4 @@ Ce glossaire est évolutif. N'hésitez pas à proposer des ajouts ou corrections
 
 - [Historique des simulateurs publics](/historique)
 - [Guide complet des simulateurs](/simulateurs/)
-- [Introduction au projet](/introduction)
+- [Introduction au produit Aides simplifiées](/introduction)

--- a/docs/historique.md
+++ b/docs/historique.md
@@ -1,6 +1,6 @@
 # Historique des simulateurs d'aides dans l'écosystème public
 
-Afin de situer le projet Aides simplifiées dans son contexte, il est utile de retracer l'évolution historique des simulateurs de prestations et de droits en France. Depuis les premiers calculateurs fiscaux des années 1990 jusqu'aux approches de "Rules as Code" aujourd'hui explorées, le rôle du numérique dans l'accès aux droits a beaucoup évolué.
+Afin de situer le produit Aides simplifiées dans son contexte, il est utile de retracer l'évolution historique des simulateurs de prestations et de droits en France. Depuis les premiers calculateurs fiscaux des années 1990 jusqu'aux approches de "Rules as Code" aujourd'hui explorées, le rôle du numérique dans l'accès aux droits a beaucoup évolué.
 
 ## Les précurseurs : premières simulations fiscales (années 1990)
 
@@ -121,7 +121,7 @@ Depuis quelques années, un mouvement international promeut l'idée de rendre le
 
 ### Facteurs de succès
 1. **Impliquer l'utilisateur** dès la conception
-2. **Associer l'expertise métier** dans l'équipe projet
+2. **Associer l'expertise métier** dans l'équipe produit
 3. **S'appuyer sur des technologies ouvertes** et éprouvées
 4. **Itérer rapidement** et améliorer en continu
 5. **Nouer des partenariats** avec les institutions métier
@@ -141,7 +141,7 @@ L'étude de cette histoire montre le chemin parcouru et celui restant à faire. 
 4. **Inclusion** : Accessibilité pour tous les publics
 
 ::: tip Pour aller plus loin
-Cette analyse historique nourrit notre réflexion prospective. Découvrez notre vision dans la [présentation du projet](/introduction).
+Cette analyse historique nourrit notre réflexion prospective. Découvrez notre vision dans la [présentation du produit Aides simplifiées](/introduction).
 :::
 
 ## Sources et références
@@ -161,6 +161,6 @@ Cette analyse historique nourrit notre réflexion prospective. Découvrez notre 
 
 ## Prochaines étapes
 
-- [Retourner à l'introduction du projet](/introduction)
+- [Retourner à l'introduction du produit Aides simplifiées](/introduction)
 - [Explorer la méthodologie des simulateurs](/simulateurs/)
 - [Consulter le glossaire technique](/glossaire)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ L'équipe Aides simplifiées a développé et géré en production plusieurs sim
 
 ## Cibles
 
-- **Expert·e·s métier** au sein d'opérateurs d'aides, de tarifs solidaires, de taxes
+- **Expert·e·s métier** au sein d'opérateurs d'aides, de tarification solidaire, de réduction de prélèvements
 - **Équipes techniques** qui souhaitent modéliser des règles ou contribuer au produit
 - **Partenaires institutionnels** intéressés par la réutilisation de nos outils
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ L'équipe Aides simplifiées a développé et géré en production plusieurs sim
 
 - **Expert·e·s métier** au sein d'opérateurs d'aides, de tarification solidaire, de réduction de prélèvements
 - **Équipes techniques** qui souhaitent modéliser des règles ou contribuer au produit
-- **Partenaires institutionnels** intéressés par la réutilisation de nos outils
+- **Partenaires institutionnels publics et privés** intéressés par la réutilisation de nos outils
 
 ::: tip
 Cette documentation est en constante évolution. N'hésitez pas à [contribuer](https://github.com/betagouv/aides-simplifiees-docs) pour l'améliorer !

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,21 +4,21 @@
 
 Cette documentation présente les méthodologies, outils et apprentissages de l'équipe [Aides simplifiées](https://beta.gouv.fr/startups/droit-data-gouv-fr-simulateurs-de-droits.html) pour modéliser des règles d'aides publiques, créer des simulateurs user-friendly et maintenir ces outils dans le temps.
 
-L'équipe Aides simplifiées a développé plusieurs simulateurs opérationnels couvrant des aides nationales et locales, et a formalisé une méthodologie de modélisation des règles. Cette documentation vise à partager ces apprentissages et à faciliter l'essaimage de telles démarches au sein de l'administration.
+L'équipe Aides simplifiées a développé et géré en production plusieurs simulateurs couvrant des aides nationales et locales, et formalise une méthodologie de modélisation des règles. Cette documentation vise à partager ces apprentissages et à faciliter la réutilisation de telles démarches au sein de l'administration.
 
 ## Objectifs
 
-- **Présenter le produit** : Faire découvrir les outils et méthodologies développés par l'équipe
-- **Aider les partenaires** : Fournir la documentation nécessaire pour intégrer ou réutiliser nos travaux  
+- **Présenter le produit** : Faire découvrir les outils et méthodologies développés
+- **Faciliter la réutilisation** : Fournir la documentation nécessaire pour intégrer ou réutiliser nos travaux  
 - **Faciliter la contribution** : Documenter les processus de contribution à la "bibliothèque de règles"
-- **Partager notre expertise** : Décrire notre méthodologie et nos apprentissages en modélisation de règles
-- **Documenter l'architecture** : Expliquer les choix techniques et l'organisation du code
+- **Partager les apprentissages** : Décrire notre méthodologie et nos apprentissages en modélisation de règles
+- **Documenter l'architecture** : Expliquer les choix techniques et l'organisation des codes produits
 
 ## Cibles
 
 - **Expert·e·s métier** au sein d'opérateurs d'aides, de tarifs solidaires, de taxes
 - **Équipes techniques** qui souhaitent modéliser des règles ou contribuer au produit
-- **Partenaires institutionnels** cherchant à réutiliser nos outils
+- **Partenaires institutionnels** intéressés par la réutilisation de nos outils
 
 ::: tip
 Cette documentation est en constante évolution. N'hésitez pas à [contribuer](https://github.com/betagouv/aides-simplifiees-docs) pour l'améliorer !
@@ -34,4 +34,3 @@ Cette documentation est en constante évolution. N'hésitez pas à [contribuer](
 
 - [Glossaire](/glossaire) des termes techniques
 - [Historique](/historique) des simulateurs dans l'écosystème public
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## À propos de cette documentation
 
-Cette documentation présente les méthodologies, outils et apprentissages de l'équipe Aides simplifiées pour modéliser des règles d'aides publiques, créer des simulateurs user-friendly et maintenir ces outils dans le temps.
+Cette documentation présente les méthodologies, outils et apprentissages de l'équipe [Aides simplifiées](https://beta.gouv.fr/startups/droit-data-gouv-fr-simulateurs-de-droits.html) pour modéliser des règles d'aides publiques, créer des simulateurs user-friendly et maintenir ces outils dans le temps.
 
 L'équipe Aides simplifiées a développé plusieurs simulateurs opérationnels couvrant des aides nationales et locales, et a formalisé une méthodologie de modélisation des règles. Cette documentation vise à partager ces apprentissages et à faciliter l'essaimage de telles démarches au sein de l'administration.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Aides simplifiées : Documentation du projet
+# Aides simplifiées : Documentation du produit
 
 ## À propos de cette documentation
 
@@ -17,7 +17,7 @@ L'équipe Aides simplifiées a développé plusieurs simulateurs opérationnels 
 ## Cibles
 
 - **Expert·e·s métier** au sein d'opérateurs d'aides, de tarifs solidaires, de taxes
-- **Équipes techniques** qui souhaitent modéliser des règles ou contribuer au projet
+- **Équipes techniques** qui souhaitent modéliser des règles ou contribuer au produit
 - **Partenaires institutionnels** cherchant à réutiliser nos outils
 
 ::: tip
@@ -26,7 +26,7 @@ Cette documentation est en constante évolution. N'hésitez pas à [contribuer](
 
 ## Commencer
 
-- [Introduction au projet](/introduction)
+- [Introduction au produit Aides simplifiées](/introduction)
 - [Pourquoi modéliser les aides ?](/pourquoi)
 - [Guide des simulateurs](/simulateurs/)
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -12,7 +12,7 @@ Les informations disponibles sur les aides publiques présentent plusieurs limit
 - **Techniques** : descriptions formulées dans un langage juridique ou administratif difficile à comprendre
 - **Dispersées** : éparpillées sur de multiples sites web et services
 
-Le parcours actuel de l'usager pour connaître ses droits est complexe et incertain, engendrant iniquité et inégalités d'accès aux aides.
+Le parcours actuel de l'usager pour connaître ses droits est complexe et incertain, ce qui accroît le risque d'iniquité et d'inégalité d'accès aux aides.
 
 ## Objectifs du produit Aides simplifiées
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,7 +2,7 @@
 
 En France, il existe une multitude d'aides publiques portées par des acteurs variés (État, collectivités locales, organismes sociaux, etc.), à destination de publics très divers. Ces dispositifs évoluent régulièrement, utilisent des critères souvent proches mais rarement identiques, et ne sont que rarement accessibles via un point d'entrée unique.
 
-**Conséquence** : il est difficile pour une personne de savoir clairement à quelles aides elle est éligible, compte tenu de sa situation réelle. Par exemple, on estime que près de 80 % des personnes éligibles à une aide pour une complémentaire santé ne la demandent pas en raison de la complexité des démarches.
+**Conséquence** : Il est difficile pour une personne de savoir clairement à quelles aides elle est éligible, compte tenu de sa situation réelle. Par exemple, on estime que près de 80 % des personnes éligibles à une aide pour une complémentaire santé ne la demandent pas en raison de la complexité des démarches.
 
 ## Problèmes identifiés
 
@@ -10,7 +10,7 @@ Les informations disponibles sur les aides publiques présentent plusieurs limit
 
 - **Parcellaires** : chaque source ne couvre qu'une partie des aides existantes
 - **Techniques** : descriptions formulées dans un langage juridique ou administratif difficile à comprendre
-- **Dispersées** : éparpillées sur de multiples sites web et services, sans portail centralisé
+- **Dispersées** : éparpillées sur de multiples sites web et services
 
 Le parcours actuel de l'usager pour connaître ses droits est complexe et incertain, engendrant iniquité et inégalités d'accès aux aides.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,10 +17,12 @@ Le parcours actuel de l'usager pour connaître ses droits est complexe et incert
 ## Objectifs du produit Aides simplifiées
 
 Pour rendre l'information plus claire et plus actionnable, au bon moment, au bon endroit, aides simplifiées travaille sur deux faces de la même pièce :
+* l'expérience utilisateur
+* la donnée de qualité
 
 ### 1. L'expérience utilisateur
 
-Pour afficher cette information à l'usager de la manière la plus UX-friendly possible (ex. via une notification proactive) via des méthodologies et outils front-end.
+Pour afficher cette information à l'usager de la manière la plus UX-friendly possible (ex. via une notification proactive [^1]) via des méthodologies et outils front-end.
 
 ### 2. La donnée de qualité
 
@@ -56,3 +58,6 @@ Parce que les règles changent, parce que les situations évoluent, parce que le
 - [Comprendre pourquoi modéliser les aides](/pourquoi)
 - [Découvrir notre approche des simulateurs](/simulateurs/)
 - [Explorer notre glossaire technique](/glossaire)
+
+[^1] Lancée à l'occasion du [sixième comité interministériel de la transformation publique](https://www.modernisation.gouv.fr/actualites/tenue-du-6eme-comite-interministeriel-de-la-transformation-publique-citp) en juillet 2021, __l'administration proactive__ a pour objectifs la lutte contre le non-recours aux droits et la simplification des démarches administratives grâce aux partages d'informations (de données) entre administrations.  
+Elle va au devant des usagers. Elle ne peut être qu'à leur bénéfice (personne physique ou personne morale) et jamais à des fins de lutte contre la fraude.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -14,7 +14,7 @@ Les informations disponibles sur les aides publiques présentent plusieurs limit
 
 Le parcours actuel de l'usager pour connaître ses droits est complexe et incertain, engendrant iniquité et inégalités d'accès aux aides.
 
-## Objectifs du projet Aides simplifiées
+## Objectifs du produit Aides simplifiées
 
 Pour rendre l'information plus claire et plus actionnable, au bon moment, au bon endroit, aides simplifiées travaille sur deux faces de la même pièce :
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,15 +22,15 @@ Pour rendre l'information plus claire et plus actionnable, au bon moment, au bon
 
 ### 1. L'expérience utilisateur
 
-Pour afficher cette information à l'usager de la manière la plus UX-friendly possible (ex. via une notification proactive [^1]) via des méthodologies et outils front-end.
+Pour afficher cette information à l'usager de la manière la plus UX-friendly possible (ex. via une notification proactive [^1]) Aides simplifiées développe des méthodologies et des interfaces numériques.
 
 ### 2. La donnée de qualité
 
-Pour que l'information affichée à l'usager soit toujours à jour et exacte, une bibliothèque de règles modélisées facilement maintenable par une communauté d'experts, ainsi que les outils qui permettent de faire circuler ou de consommer cette "donnée".
+Pour que l'information affichée à l'usager soit toujours à jour, exacte et transparente, Aides simplifiées contribue à une bibliothèque de règles modélisées facilement maintenable par une communauté d'experts, ainsi que les outils qui permettent de faire circuler ou de consommer cette "donnée".
 
 ## Notre approche
 
-Nous développons des **outils publics, gratuits et réutilisables** délivrant une information personnalisée à l'usager sur les aides auxquelles il peut prétendre : la bonne aide, au bon moment au bon endroit. 
+Nous développons des **outils publics, gratuits, ouverts et réutilisables** délivrant une information personnalisée à l'usager sur les aides auxquelles il peut prétendre : la bonne aide, au bon moment au bon endroit. 
 
 Notre rôle est d'apporter aux personnes concernées une réponse rapide à la question :
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -34,11 +34,11 @@ Nous développons des **outils publics, gratuits, ouverts et réutilisables** d�
 
 Notre rôle est d'apporter aux personnes concernées une réponse rapide à la question :
 
-> **"À quelles aides puis-je prétendre dans ma situation, ici et maintenant ?"**
+> **"À quelles aides puis-je prétendre dans ma situation, ici et à date ?"**
 
-Ces informations personnalisées à l'usager sur les aides auxquels il a droit, qu'elles prennent la forme de simulateurs, de notifications proactives ou de chatbot, reposent sur une **bibliothèque de règles modélisées** à partir des textes réglementaires, dans des langages et moteurs de calcul open source.
+Ces informations personnalisées à l'usager sur les aides auxquels il a droit, qu'elles qu'en soit la forme (simulateurs, notifications proactives, chatbot, ...), reposent sur une **bibliothèque de règles modélisées** à partir des textes réglementaires, dans des langages et moteurs de calcul __open source__.
 
-Nous publions aussi les composants, la documentation technique et les principes méthodologiques pour faciliter la réutilisation et la contribution de nos travaux.
+Nous publions aussi en __open source__ les composants, la documentation technique et les principes méthodologiques pour faciliter la réutilisation et la contribution de nos travaux.
 
 ## Nos principes
 
@@ -47,7 +47,7 @@ Parce que les règles changent, parce que les situations évoluent, parce que le
 - **Structurés autour de règles lisibles et vérifiables**
 - **Conçus pour être maintenus dans le temps**  
 - **Pensés pour l'interopérabilité**
-- **Développés en open source, par défaut**
+- **Développés en open source contributifs, par défaut**
 
 ::: info État d'avancement
 À date, nous avons développé plusieurs simulateurs opérationnels et documenté notre méthodologie de modélisation des règles d'aides publiques.

--- a/docs/pourquoi.md
+++ b/docs/pourquoi.md
@@ -1,8 +1,12 @@
- # À quoi ça sert ? Pourquoi on fait ça ?
+# À quoi ça sert ? Pourquoi fait-on ça ?
 
-## Égalité et équité
+## Égalité, équité et efficacité
 
-La modélisation des règles d'aides publiques s'inscrit dans une démarche d'**égalité** et d'**équité** territoriale et sociale. En rendant l'information accessible de manière uniforme, nous contribuons à réduire les inégalités d'accès aux droits.
+La transcription en algorithmes des règles d'aides publiques est largement appliquée par les services de l'Etat depuis de nombreuses années. 
+
+Faciliter aujourd'hui la circulation de ces modélisations s'inscrit dans une démarche : 
+* d'**efficacité** du service public : lorsqu'un dispositif d'aide est décidé, il s'agit de contribuer à sa diffusion auprès du public concerné.
+* d'**égalité** et d'**équité** territoriale et sociale : en rendant l'information accessible de manière uniforme, nous contribuons à réduire les inégalités d'accès aux droits.
 
 ## Contexte et enjeux
 

--- a/docs/simulateurs/importance-modelisation.md
+++ b/docs/simulateurs/importance-modelisation.md
@@ -88,7 +88,7 @@ On passe d'une **règle implicite** à une **règle visible et partageable**.
 
 ### Le défi de la communication
 
-Dans un projet d'aide publique interviennent :
+Dans un produit dédié à un dispositif d'aide publique interviennent :
 - **Experts métier** : connaissent les règles mais pas forcément la technique
 - **Juristes** : maîtrisent les textes mais pas l'UX
 - **Designers** : pensent parcours utilisateur mais pas réglementation

--- a/docs/simulateurs/index.md
+++ b/docs/simulateurs/index.md
@@ -62,6 +62,6 @@ API, widget, iframe pour intégrer dans d'autres sites.
 
 Choisissez votre point d'entrée selon votre besoin :
 
-- **Nouveau projet** → [Modéliser une aide](/simulateurs/modeliser-une-aide)
-- **Projet complexe** → [Simulateur multi-aide](/simulateurs/simulateur-multi-aide)  
+- **Nouveau produit** → [Modéliser une aide](/simulateurs/modeliser-une-aide)
+- **Produit complexe** → [Simulateur multi-aide](/simulateurs/simulateur-multi-aide)  
 - **Questionnement méthodologique** → [Importance de la modélisation](/simulateurs/importance-modelisation)


### PR DESCRIPTION
**Pourquoi les `projet` ont été renommés en `produit` ?** 

Parce qu'on a globalement appliqué la démarche produit beta.gouv.fr. Pour en savoir plus sur les différences, un résumé rapide est disponible ici : https://doc.incubateur.net/communaute/gerer-son-produit/approche-produit